### PR TITLE
Created a simple way of using the FishyUnityTransport Relay capabilities

### DIFF
--- a/Assets/FishNet/Plugins/FishyUnityTransport/FishyUnityTransport.asmdef
+++ b/Assets/FishNet/Plugins/FishyUnityTransport/FishyUnityTransport.asmdef
@@ -6,7 +6,8 @@
         "GUID:e0cd26848372d4e5c891c569017e11f1",
         "GUID:fe25561d224ed4743af4c60938a59d0b",
         "GUID:f2d49d9fa7e7eb3418e39723a7d3b92f",
-        "GUID:2665a8d13d1b3f18800f46e256720795"
+        "GUID:2665a8d13d1b3f18800f46e256720795",
+        "GUID:03058786646e84a4587858e9302c3f41"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Assets/FishNet/Plugins/FishyUnityTransport/FishyUnityTransportRelayManager.cs
+++ b/Assets/FishNet/Plugins/FishyUnityTransport/FishyUnityTransportRelayManager.cs
@@ -1,0 +1,110 @@
+﻿using System;
+using System.Threading.Tasks;
+using FishNet.Managing;
+using FishNet.Transporting.FishyUnityTransport;
+using Unity.Networking.Transport.Relay;
+using Unity.Services.Relay;
+using Unity.Services.Relay.Models;
+using UnityEngine;
+
+public class FishyUnityTransportRelayManager : MonoBehaviour
+{
+    public int MaxConnections = 10;
+    [SerializeField] private string _currentRelayJoinCode;
+    [SerializeField] private bool _log;
+    
+    private NetworkManager _networkManager;
+    
+    private void Awake()
+    {
+        _networkManager = FindObjectOfType<NetworkManager>();
+        if (_networkManager == null)
+        {
+            Debug.LogError("NetworkManager not found, cannot start relay server.");
+        }
+    }
+    
+    public async void StartServerWithRelay()
+    {
+        await AllocateRelayServerAndGetJoinCode(MaxConnections);
+    }
+    
+    public async void StartHostWithRelay()
+    {
+        await AllocateRelayServerAndGetJoinCode(MaxConnections);
+        await JoinRelayServerFromJoinCode(_currentRelayJoinCode);
+    }
+
+    public async void StartClientWithRelay(string joinCode)
+    {
+        await JoinRelayServerFromJoinCode(joinCode);
+    }
+
+    private async Task<RelayServerData> AllocateRelayServerAndGetJoinCode(int maxConnections, string region = null)
+    {
+        if(_log) Debug.Log("Relay server : creating allocation...");
+        RelayServerData relayServerData;
+        Allocation currentAllocation;
+        try
+        {
+            // Setup HostAllocation
+            currentAllocation = await RelayService.Instance.CreateAllocationAsync(maxConnections, region);
+            // Get FishyUnityTransport
+            var fishyUnityTransport = (FishyUnityTransport)_networkManager.TransportManager.Transport;
+            
+            relayServerData = new RelayServerData(currentAllocation, "dtls");
+            fishyUnityTransport.SetRelayServerData(relayServerData);
+            
+            // Start Server Connection
+            _networkManager.ServerManager.StartConnection();
+            
+            if(_log) Debug.Log("Relay server : allocation successfully created");
+        }
+        catch (Exception e)
+        {
+            Debug.LogError($"Relay server : create allocation request failed {e.Message}");
+            throw;
+        }
+
+        if(_log) Debug.Log($"Relay server : {currentAllocation.ConnectionData[0]} {currentAllocation.ConnectionData[1]}");
+        if(_log) Debug.Log($"Relay server : {currentAllocation.AllocationId}");
+
+        if (_log) Debug.Log("Relay server : getting Join Code...");
+        
+        try
+        {
+            _currentRelayJoinCode = await RelayService.Instance.GetJoinCodeAsync(currentAllocation.AllocationId);
+            if (_log) Debug.Log("Relay server : join code -> " + _currentRelayJoinCode);
+            // If you want to update the lobby metadata with the join code, you can do it here.
+        }
+        catch
+        {
+            Debug.LogError("Relay server : join code request failed");
+            throw;
+        }
+
+        return relayServerData;
+    }
+
+    private async Task<RelayServerData> JoinRelayServerFromJoinCode(string joinCode)
+    {
+        if(_log) Debug.Log("Relay server : joining Relay Server...");
+        JoinAllocation joinAllocation;
+        
+        try
+        {
+            joinAllocation = await RelayService.Instance.JoinAllocationAsync(joinCode);
+            var fishyUnityTransport = (FishyUnityTransport)_networkManager.TransportManager.Transport;
+            fishyUnityTransport.SetRelayServerData(new RelayServerData(joinAllocation, "dtls"));
+            _networkManager.ClientManager.StartConnection();
+            if(_log) Debug.Log("Relay server : joined Relay Server");
+        }
+        catch
+        {
+            Debug.LogError("Relay server : attempt to join Relay Server failed");
+            throw;
+        }
+
+        return new RelayServerData(joinAllocation, "dtls");
+    }
+}

--- a/Assets/FishNet/Plugins/FishyUnityTransport/FishyUnityTransportRelayManager.cs.meta
+++ b/Assets/FishNet/Plugins/FishyUnityTransport/FishyUnityTransportRelayManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0fafb76caf9748e498d5372d7fd40805
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,15 @@ Make sure you have the following packages installed:
 ## Unity Relay support
 This library supports Unity Relay, and since its API is similar to the UnityTransport for NGO API, I recommend reading the official Relay **[documentation](https://docs.unity.com/relay/en/manual/relay-and-ngo)**.
 
+To setup Unity Relay with Fishy Unity Transport follow these steps :
+1. Complete all steps above from `Setting Up`.
+2. Make sure you have installed and set up **Unity Authentication Service**, which is required to use the Relay services. **[AuthenticationService](https://docs.unity.com/authentication/en/manual/sign-up-for-ugs)**
+3. Make sure you are signing-in when entering Play Mode with the authentication service before using Unity Relay.
+4. Set the `ProtocoleType` field of the `FishyUnityTransport` component to `Relay Unity Transport`.
+5. Add the `FishyUnityTransportRelayManager` component to your `NetworkManager`
+6. Call one of the three method of `FishyUnityTransportRelayManager` : `StartHostWithRelay()`, `StartClientWithRelay(string joinCode)`, `StartServerWithRelay()`
+
+
 ### Simple host connection sample:
 ```csharp
 // Get FishyUnityTransport

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ To setup Unity Relay with Fishy Unity Transport follow these steps :
 2. Make sure you have installed and set up **Unity Authentication Service**, which is required to use the Relay services. **[AuthenticationService](https://docs.unity.com/authentication/en/manual/sign-up-for-ugs)**
 3. Make sure you are signing-in when entering Play Mode with the authentication service before using Unity Relay.
 4. Set the `ProtocoleType` field of the `FishyUnityTransport` component to `Relay Unity Transport`.
-5. Add the `FishyUnityTransportRelayManager` component to your `NetworkManager`
-6. Call one of the three method of `FishyUnityTransportRelayManager` : `StartHostWithRelay()`, `StartClientWithRelay(string joinCode)`, `StartServerWithRelay()`
+5. Add the `FishyUnityTransportRelayManager` component to your `NetworkManager`.
+6. Call one of the three method of `FishyUnityTransportRelayManager` : `StartHostWithRelay()`, `StartClientWithRelay(string joinCode)`, `StartServerWithRelay()`.
 
 
 ### Simple host connection sample:


### PR DESCRIPTION
First, thank you for maintaining a FishNet plugin to support Unity Relay's feature !

I added a FishyUnityTransportRelayManager component with these features : 

- A simple way to start an allocation as Host using relay and getting a JoinCode with a `StartHostWithRelay()` method.
- A simple way to join a relay server as a client with a `StartClientWithRelay(string joinCode)` method

There is also a `StartServerWithRelay()` method that you can use.
I modified the Assembly Definition to add Unity.Services.Relay. (this might be an issue if people wants to use the Unity Transport with FishNet without wanting to use Relay)

Everything's asynchronous for the relay creation and joining.

I also added a Tutorial to the README, on how to set it up, especially the Authentication part that will not work without it.
