### PR TITLE
Fix exception in UnityTransport when DisconnectLocalClient was called

### DIFF
--- a/Assets/FishNet/Plugins/FishyUnityTransport/UnityTransport.cs
+++ b/Assets/FishNet/Plugins/FishyUnityTransport/UnityTransport.cs
@@ -999,8 +999,6 @@ namespace FishNet.Transporting.UTP
 
                 if (m_Driver.Disconnect(ParseClientId(m_ServerClientId)) == 0)
                 {
-                    m_State = State.Disconnected;
-
                     m_ReliableReceiveQueues.Remove(m_ServerClientId);
                     ClearSendQueuesForClientId(m_ServerClientId);
 


### PR DESCRIPTION
The exception was the following: 
ArgumentOutOfRangeException
thrown by HandleTransportDataEvent
called by ReceiveMessages
called by ProcessEvent
called by ShutdownInternals
called by DisconnectLocalClient()

Since the exception arose when trying to handle data events while m_State is Disconnected, I removed the m_State = Disconnected from the DisconnectLocalClient() method. ShutdownInternals already sets the m_State variable to Disconnected after it's down handling events.